### PR TITLE
BUG Fix git sparse-checkout call

### DIFF
--- a/src/package_downloads/package_names.py
+++ b/src/package_downloads/package_names.py
@@ -27,7 +27,7 @@ async def clone_repodata_archive(repodata_archive: Path, channel_url: str) -> No
         ".",
     )
     git("sparse-checkout", "init")
-    git("sparse-checkout", "set", f"repodata/{escape_path(channel_url)}/*/repodata.json")
+    git("sparse-checkout", "set", "--no-cone", f"repodata/{escape_path(channel_url)}/*/repodata.json")
     git("checkout", "--quiet")
 
 


### PR DESCRIPTION
The actions keep failing and I think that one must use `--no-cone` to use patterns, but it seems to depend on the exact version of git being used.