### PR TITLE
fix git 2.49.0 compatibility

### DIFF
--- a/.github/workflows/packages-anaconda-org.yml
+++ b/.github/workflows/packages-anaconda-org.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check
       id: check

--- a/.github/workflows/packages-anaconda-org.yml
+++ b/.github/workflows/packages-anaconda-org.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fetch-anaconda-org-stats:
     name: Fetch anaconda.org stats
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       id: fetch
       run: |
         set -x
-        ref="$( git show-ref --head --hash HEAD )"
+        ref="$( git show-ref --head --hash main/HEAD )"
         pip install \
           ntplib \
           aiohttp requests urllib3 \

--- a/.github/workflows/packages-anaconda-org.yml
+++ b/.github/workflows/packages-anaconda-org.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fetch-anaconda-org-stats:
     name: Fetch anaconda.org stats
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
git 2.49.0 deployed last week in github actions - and every stats update action using it has failed since.
It turns out that git's show-ref is behaving differently - and we need to be super-specific when using that.  Asking for 'main/HEAD' is works.

with 2.48.1:  
git show-ref --head  HEAD
3934e04b5be14c99941cba716f5e8ae6f697d990 HEAD

with 2.49.0: 
git show-ref --head  HEAD
3934e04b5be14c99941cba716f5e8ae6f697d990 HEAD
3934e04b5be14c99941cba716f5e8ae6f697d990 refs/remotes/origin/HEAD

with 2.48.1:
git show-ref --head  main/HEAD
3934e04b5be14c99941cba716f5e8ae6f697d990 HEAD
with 2.49.0:
git show-ref --head  main/HEAD
3934e04b5be14c99941cba716f5e8ae6f697d990 HEAD

this PR does that, and bumps to github's checkout action v4 instead of v3, although that isn't related to this fix.